### PR TITLE
Updates em-simple_telnet to correctly handle panic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/pixelblend/radiodan.git
-  revision: b65bfa17b540260baecf3a95701caf7b38ff9a18
+  revision: 2c830eac82f6c48701d98eac9fd8a2623f44f299
   branch: master
   specs:
     radiodan (0.0.4)
@@ -34,7 +34,7 @@ GEM
       eventmachine (>= 1.0.0.beta.4)
       http_parser.rb (>= 0.5.3)
     em-resolv-replace (1.1.3)
-    em-simple_telnet (0.0.14)
+    em-simple_telnet (0.0.15)
       eventmachine (>= 1.0.0)
     em-socksify (0.3.0)
       eventmachine (>= 1.0.0.beta.4)
@@ -43,8 +43,8 @@ GEM
     eventmachine (1.0.3)
     http_parser.rb (0.5.3)
     i18n (0.6.5)
-    method_source (0.8.1)
-    mime-types (1.23)
+    method_source (0.8.2)
+    mime-types (1.25)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -66,7 +66,7 @@ GEM
       eventmachine (~> 1.0.0)
       rack-fiber_pool (~> 0.9)
       sinatra (~> 1.0)
-    slop (3.4.5)
+    slop (3.4.6)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)


### PR DESCRIPTION
Panic was failing with

```
/var/lib/gems/1.9.1/gems/em-simple_telnet-0.0.14/lib/em-simple_telnet.rb:374:in `resume': fiber called across threads (FiberError)
from /var/lib/gems/1.9.1/gems/em-simple_telnet-0.0.14/lib/em-simple_telnet.rb:374:in `block in initialize'
from /var/lib/gems/1.9.1/gems/em-simple_telnet-0.0.14/lib/em-simple_telnet.rb:969:in `call'
from /var/lib/gems/1.9.1/gems/em-simple_telnet-0.0.14/lib/em-simple_telnet.rb:969:in `connection_completed'
from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run_machine'
from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
from /var/lib/gems/1.9.1/gems/em-synchrony-1.0.3/lib/em-synchrony.rb:38:in `synchrony'
from /home/vagrant/.bundler/ruby/1.9.1/radiodan-b65bfa17b540/lib/radiodan.rb:24:in `start'
from ./bin/start:29:in `<main>'
```

Updating em-simple_telnet fixes the issue
